### PR TITLE
Added IE Treated Wood Siding, Moulding, and Corners

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ minecraft {
 }
 
 repositories {
+    maven { url "http://maven.amadornes.com/" }
+    maven { url "http://www.ryanliptak.com/maven/" }
+    maven { url "http://maven.tterrag.com" }
+
     maven { url 'http://dvs1.progwml6.com/files/maven' }
     maven { url "http://blamejared.com/maven" }
     maven {
@@ -40,6 +44,7 @@ repositories {
 }
 
 dependencies {
+    deobfCompile "team.chisel.ctm:CTM:MC1.12-0.2.3.9"
     deobfCompile "betterwithmods:BetterWithMods:+"
     deobfCompile "blusunrize:ImmersiveEngineering:+"
     deobfCompile "cofh:ThermalExpansion:1.12-5.3.5.19:deobf"

--- a/src/main/java/betterwithengineering/BWE.java
+++ b/src/main/java/betterwithengineering/BWE.java
@@ -55,6 +55,9 @@ public class BWE {
 		@Config.Comment("Allow IE Windmill and Waterwheel to output to wooden axles")
 		public static boolean mechanicalPower = true;
 
+        @Config.Comment("Add Treated Wood IE Siding, Moulding and Corners")
+        public static boolean addTreatedWood= true;
+
 		@Config.Name("thermalexpansion")
 		public static ThermalExpansion thermalExpansion = new ThermalExpansion();
 

--- a/src/main/java/betterwithengineering/base/CompatLoader.java
+++ b/src/main/java/betterwithengineering/base/CompatLoader.java
@@ -4,6 +4,7 @@ import betterwithengineering.BWE;
 import betterwithengineering.ThermalExpansion;
 import betterwithengineering.ie.HempFix;
 import betterwithengineering.ie.MechPower;
+import betterwithengineering.ie.TreatedWood;
 import betterwithmods.module.Feature;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
@@ -24,6 +25,10 @@ public class CompatLoader {
             COMPAT_CLASS.put("immersiveengineering", MechPower.class);
         if(BWE.ConfigManager.overrideIndustrialHempDrops)
             COMPAT_CLASS.put("immersiveengineering", HempFix.class);
+        if(BWE.ConfigManager.addTreatedWood) {
+            COMPAT_CLASS.put("immersiveengineering", TreatedWood.class);
+        }
+
         COMPAT_CLASS.put("thermalexpansion", ThermalExpansion.class);
         for (String key : COMPAT_CLASS.keySet()) {
             if (Loader.isModLoaded(key)) {

--- a/src/main/java/betterwithengineering/ie/TreatedWood.java
+++ b/src/main/java/betterwithengineering/ie/TreatedWood.java
@@ -1,0 +1,103 @@
+package betterwithengineering.ie;
+
+import betterwithmods.common.BWMBlocks;
+import betterwithmods.common.blocks.mini.BlockCorner;
+import betterwithmods.common.blocks.mini.BlockMoulding;
+import betterwithmods.common.blocks.mini.BlockSiding;
+import betterwithmods.common.blocks.mini.ItemBlockMini;
+import betterwithmods.common.items.ItemMaterial;
+import betterwithmods.module.Feature;
+import betterwithmods.module.gameplay.SawRecipes;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.oredict.OreDictionary;
+
+import static betterwithmods.common.BWOreDictionary.registerOre;
+
+
+public class TreatedWood extends Feature {
+
+    protected final String modid;
+
+    public TreatedWood() {
+        configName = "TreatedWood";
+        modid = "immersiveengineering";
+    }
+
+    public String[] woods = { "horizontal", "vertical", "packaged"};
+
+    public static Block SIDING = new BlockSiding(Material.WOOD) {
+        @Override
+        public int getUsedTypes() {
+            return 3;
+        }
+
+    }.setRegistryName("ie_siding");
+    public static Block MOULDING = new BlockMoulding(Material.WOOD) {
+        @Override
+        public int getUsedTypes() {
+            return 3;
+        }
+
+    }.setRegistryName("ie_moulding");
+    public static Block CORNER = new BlockCorner(Material.WOOD) {
+        @Override
+        public int getUsedTypes() {
+            return 3;
+        }
+    }.setRegistryName("ie_corner");
+
+
+    @Override
+    public void preInit(FMLPreInitializationEvent event) {
+        BWMBlocks.registerBlock(SIDING, new ItemBlockMini(SIDING));
+        BWMBlocks.registerBlock(MOULDING, new ItemBlockMini(MOULDING));
+        BWMBlocks.registerBlock(CORNER, new ItemBlockMini(CORNER));
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void preInitClient(FMLPreInitializationEvent event) {
+        BWMBlocks.setInventoryModel(SIDING);
+        BWMBlocks.setInventoryModel(MOULDING);
+        BWMBlocks.setInventoryModel(CORNER);
+    }
+
+    @Override
+    public void init(FMLInitializationEvent event) {
+        super.init(event);
+
+        Block treated_wood = getBlock(modid + ":treated_wood");
+        Block treated_slab = getBlock(modid + ":treated_wood_slab");
+        for (int i = 0; i < 3; i++) {
+            SawRecipes.addSawRecipe(treated_wood, i, new ItemStack(SIDING, 2, i));
+            SawRecipes.addSawRecipe(SIDING, i, new ItemStack(MOULDING, 2, i));
+            SawRecipes.addSawRecipe(MOULDING, i, new ItemStack(CORNER, 2, i));
+            SawRecipes.addSawRecipe(CORNER, i, ItemMaterial.getMaterial(ItemMaterial.EnumMaterial.GEAR, 2));
+            SawRecipes.addSawRecipe(treated_slab, i, new ItemStack(MOULDING, 2, i));
+
+        }
+
+        registerOre("sidingTreatedWood", new ItemStack(SIDING, 1, OreDictionary.WILDCARD_VALUE));
+        registerOre("sidingWood", new ItemStack(SIDING, 1, OreDictionary.WILDCARD_VALUE));
+
+        registerOre("slabTreatedWood", new ItemStack(SIDING, 1, OreDictionary.WILDCARD_VALUE));
+
+        registerOre("mouldingTreatedWood", new ItemStack(MOULDING, 1, OreDictionary.WILDCARD_VALUE));
+        registerOre("mouldingWood", new ItemStack(MOULDING, 1, OreDictionary.WILDCARD_VALUE));
+
+        registerOre("cornerTreatedWood", new ItemStack(CORNER, 1, OreDictionary.WILDCARD_VALUE));
+        registerOre("cornerWood", new ItemStack(CORNER, 1, OreDictionary.WILDCARD_VALUE));
+
+    }
+
+    public Block getBlock(String location) {
+        return Block.REGISTRY.getObject(new ResourceLocation(location));
+    }
+}

--- a/src/main/java/betterwithengineering/ie/TreatedWoodRecipeConditionFactory.java
+++ b/src/main/java/betterwithengineering/ie/TreatedWoodRecipeConditionFactory.java
@@ -1,0 +1,15 @@
+package betterwithengineering.ie;
+
+import betterwithengineering.BWE;
+import com.google.gson.JsonObject;
+import net.minecraftforge.common.crafting.IConditionFactory;
+import net.minecraftforge.common.crafting.JsonContext;
+
+import java.util.function.BooleanSupplier;
+
+public class TreatedWoodRecipeConditionFactory implements IConditionFactory {
+    @Override
+    public BooleanSupplier parse(JsonContext context, JsonObject json) {
+        return () -> BWE.ConfigManager.addTreatedWood;
+    }
+}

--- a/src/main/resources/assets/betterwithengineering/blockstates/ie_corner.json
+++ b/src/main/resources/assets/betterwithengineering/blockstates/ie_corner.json
@@ -1,0 +1,83 @@
+{
+  "forge_marker": 1,
+  "defaults": {
+    "textures": {
+      "side": "blocks/planks_oak",
+      "particle": "#side"
+    },
+    "model": "betterwithmods:mini/corner",
+    "uvlock": true
+  },
+  "variants": {
+    "normal": [
+      {}
+    ],
+    "inventory": [
+      {
+        "transform": "forge:default-block"
+      }
+    ],
+    "type": {
+      "0": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood"
+        }
+      },
+      "1": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood_vertical"
+        }
+      },
+      "2": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood_packaged"
+        }
+      },
+      "3": {
+
+      },
+      "4": {
+      },
+      "5": {
+      },
+      "6": {
+      },
+      "7": {},
+      "8": {},
+      "9": {},
+      "10": {},
+      "11": {},
+      "12": {},
+      "13": {},
+      "14": {},
+      "15": {}
+    },
+    "orientation": {
+      "0": {},
+      "1": {
+        "y": 90
+      },
+      "2": {
+        "y": 270
+      },
+      "3": {
+        "y": 180
+      },
+      "4": {
+        "x": 90
+      },
+      "5": {
+        "x": 90,
+        "y": 90
+      },
+      "6": {
+        "x": 90,
+        "y": 270
+      },
+      "7": {
+        "x": 90,
+        "y": 180
+      }
+    }
+  }
+}

--- a/src/main/resources/assets/betterwithengineering/blockstates/ie_moulding.json
+++ b/src/main/resources/assets/betterwithengineering/blockstates/ie_moulding.json
@@ -1,0 +1,98 @@
+{
+  "forge_marker": 1,
+  "defaults": {
+    "textures": {
+      "side": "blocks/planks_oak",
+      "particle": "#side"
+    },
+    "model": "betterwithmods:mini/moulding",
+    "uvlock": true
+  },
+  "variants": {
+    "normal": [
+      {}
+    ],
+    "inventory": [
+      {
+        "transform": "forge:default-block"
+      }
+    ],
+    "type": {
+      "0": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood"
+        }
+      },
+      "1": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood_vertical"
+        }
+      },
+      "2": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood_packaged"
+        }
+      },
+      "3": {
+      },
+      "4": {
+      },
+      "5": {
+      },
+      "6": {
+      },
+      "7": {},
+      "8": {},
+      "9": {},
+      "10": {},
+      "11": {},
+      "12": {},
+      "13": {},
+      "14": {},
+      "15": {}
+    },
+    "orientation": {
+      "0": {
+        "y":180
+      },
+      "1": {
+        "y":270
+      },
+      "2": {
+        "y":90
+      },
+      "3": {
+
+      },
+      "4": {
+        "x":180,
+        "y":180
+      },
+      "5": {
+        "y":270,
+        "x":180
+      },
+      "6": {
+        "y":90,
+        "x":180
+      },
+      "7": {
+        "x":180
+      },
+      "8": {
+        "x":90,
+        "y":180
+      },
+      "9": {
+        "x":270
+      },
+      "10": {
+        "x":90,
+        "y":90
+      },
+      "11": {
+        "x":90
+      }
+    }
+  }
+}

--- a/src/main/resources/assets/betterwithengineering/blockstates/ie_siding.json
+++ b/src/main/resources/assets/betterwithengineering/blockstates/ie_siding.json
@@ -1,0 +1,76 @@
+{
+  "forge_marker": 1,
+  "defaults": {
+    "textures": {
+      "side": "blocks/planks_oak",
+      "particle": "#side"
+    },
+    "model": "betterwithmods:mini/siding",
+    "uvlock": true
+  },
+  "variants": {
+    "normal": [
+      {}
+    ],
+    "inventory": [
+      {
+        "transform": "forge:default-block"
+      }
+    ],
+    "type": {
+      "0": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood"
+        }
+      },
+      "1": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood_vertical"
+        }
+      },
+      "2": {
+        "textures": {
+          "side": "immersiveengineering:blocks/treated_wood_packaged"
+        }
+      },
+      "3": {
+      },
+      "4": {
+      },
+      "5": {
+      },
+      "6": {
+      },
+      "7": {},
+      "8": {},
+      "9": {},
+      "10": {},
+      "11": {},
+      "12": {},
+      "13": {},
+      "14": {},
+      "15": {}
+    },
+    "orientation": {
+      "0": {},
+      "1": {
+        "x": 180
+      },
+      "2": {
+        "x": 270
+      },
+      "3": {
+        "x": 270,
+        "y": 180
+      },
+      "4": {
+        "x": 270,
+        "y": 270
+      },
+      "5": {
+        "x": 270,
+        "y": 90
+      }
+    }
+  }
+}

--- a/src/main/resources/assets/betterwithengineering/lang/en_us.lang
+++ b/src/main/resources/assets/betterwithengineering/lang/en_us.lang
@@ -1,0 +1,12 @@
+
+tile.bwmneering:ie_siding.0.name=Horizontal Treated Wood Siding
+tile.bwmneering:ie_moulding.0.name=Horizontal Treated Wood Moulding
+tile.bwmneering:ie_corner.0.name=Horizontal Treated Wood Corner
+
+tile.bwmneering:ie_siding.1.name=Vertical Treated Wood Siding
+tile.bwmneering:ie_moulding.1.name=Vertical Treated Wood Moulding
+tile.bwmneering:ie_corner.1.name=Vertical Treated Wood Corner
+
+tile.bwmneering:ie_siding.2.name=Packaged Treated Wood Siding
+tile.bwmneering:ie_moulding.2.name=Packaged Treated Wood Moulding
+tile.bwmneering:ie_corner.2.name=Packaged Treated Wood Corner

--- a/src/main/resources/assets/betterwithengineering/recipes/_constants.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/_constants.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "mouldingTreatedWood",
+    "ingredient": [
+      {
+        "type": "forge:ore_dict",
+        "ore": "mouldingTreatedWood"
+      }
+    ]
+  },
+  {
+    "name": "sidingTreatedWood",
+    "ingredient": [
+      {
+        "type": "forge:ore_dict",
+        "ore": "sidingTreatedWood"
+      }
+    ]
+  }
+]

--- a/src/main/resources/assets/betterwithengineering/recipes/_factories.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/_factories.json
@@ -1,0 +1,5 @@
+{
+  "conditions": {
+    "config": "betterwithengineering.ie.TreatedWoodRecipeConditionFactory"
+  }
+}

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/he_treated_fence.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/he_treated_fence.json
@@ -1,0 +1,21 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "immersiveengineering:wooden_decoration",
+    "data": 0,
+    "count": 2
+  },
+  "type": "forge:ore_shaped",
+  "pattern": [
+    "mmm"
+  ],
+  "key": {
+    "m": {
+      "item": "#mouldingTreatedWood"
+    }
+  }
+}

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/he_treated_scaffolding.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/he_treated_scaffolding.json
@@ -1,0 +1,26 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "immersiveengineering:wooden_decoration",
+    "data": 1,
+    "count": 6
+  },
+  "type": "forge:ore_shaped",
+  "pattern": [
+    "sss",
+    " m ",
+    "m m"
+  ],
+  "key": {
+    "s": {
+      "item": "#sidingTreatedWood"
+    },
+    "m": {
+      "item": "#mouldingTreatedWood"
+    }
+  }
+}

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/he_treated_sticks.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/he_treated_sticks.json
@@ -1,0 +1,17 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "immersiveengineering:material",
+    "data": 0
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "#mouldingTreatedWood"
+    }
+  ]
+}

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/he_treated_wall_mount.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/he_treated_wall_mount.json
@@ -1,0 +1,25 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "immersiveengineering:wooden_device1",
+    "data": 4,
+    "count": 4
+  },
+  "type": "forge:ore_shaped",
+  "pattern": [
+    "ss ",
+    "sm "
+  ],
+  "key": {
+    "s": {
+      "item": "#sidingTreatedWood"
+    },
+    "m": {
+      "item": "#mouldingTreatedWood"
+    }
+  }
+}

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated0_moulding_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated0_moulding_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "betterwithengineering:ie_moulding",
+    "data": 0
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_corner",
+      "data": 0
+    },
+    {
+      "item": "betterwithengineering:ie_corner",
+      "data": 0
+    }
+  ]
+}
+

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated0_plank_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated0_plank_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "immersiveengineering:treated_wood",
+    "data": 0
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_siding",
+      "data": 0
+    },
+    {
+      "item": "betterwithengineering:ie_siding",
+      "data": 0
+    }
+  ]
+}
+

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated0_siding_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated0_siding_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "betterwithengineering:ie_siding",
+    "data": 0
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_moulding",
+      "data": 0
+    },
+    {
+      "item": "betterwithengineering:ie_moulding",
+      "data": 0
+    }
+  ]
+}
+

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated1_moulding_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated1_moulding_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "betterwithengineering:ie_moulding",
+    "data": 1
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_corner",
+      "data": 1
+    },
+    {
+      "item": "betterwithengineering:ie_corner",
+      "data": 1
+    }
+  ]
+}
+

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated1_plank_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated1_plank_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "immersiveengineering:treated_wood",
+    "data": 1
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_siding",
+      "data": 1
+    },
+    {
+      "item": "betterwithengineering:ie_siding",
+      "data": 1
+    }
+  ]
+}
+

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated1_siding_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated1_siding_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "betterwithengineering:ie_siding",
+    "data": 1
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_moulding",
+      "data": 1
+    },
+    {
+      "item": "betterwithengineering:ie_moulding",
+      "data": 1
+    }
+  ]
+}
+

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated2_moulding_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated2_moulding_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "betterwithengineering:ie_moulding",
+    "data": 2
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_corner",
+      "data": 2
+    },
+    {
+      "item": "betterwithengineering:ie_corner",
+      "data": 2
+    }
+  ]
+}
+

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated2_plank_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated2_plank_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "immersiveengineering:treated_wood",
+    "data": 2
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_siding",
+      "data": 2
+    },
+    {
+      "item": "betterwithengineering:ie_siding",
+      "data": 2
+    }
+  ]
+}
+

--- a/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated2_siding_recover.json
+++ b/src/main/resources/assets/betterwithengineering/recipes/treatedwood/ie_wood_treated2_siding_recover.json
@@ -1,0 +1,23 @@
+{
+  "conditions": [
+    {
+      "type": "betterwithengineering:config"
+    }
+  ],
+  "result": {
+    "item": "betterwithengineering:ie_siding",
+    "data": 2
+  },
+  "type": "forge:ore_shapeless",
+  "ingredients": [
+    {
+      "item": "betterwithengineering:ie_moulding",
+      "data": 2
+    },
+    {
+      "item": "betterwithengineering:ie_moulding",
+      "data": 2
+    }
+  ]
+}
+


### PR DESCRIPTION
This patch adds the IE Treated Wood Siding, Moulding, and Corners that were removed when BWM updated to 1.12.

I did not add the High Efficiency Recipes, I need guidance on how to query if that option was set.